### PR TITLE
Add OkHttp, extend timeout on retrofit service

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,7 @@ ext {
     retrofitVersion = '2.8.1'
     moshiVersion = '1.9.2'
     glideVersion = '4.11.0'
+    okhttpVersion = '4.6.0'
 }
 
 dependencies {
@@ -72,6 +73,9 @@ dependencies {
     //Retrofit
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+
+    //OKHTTP
+    implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
 
     //Moshi
     implementation("com.squareup.moshi:moshi-kotlin:$moshiVersion")

--- a/app/src/main/java/com/seank/kotlinflowplayground/di/ApplicationModule.kt
+++ b/app/src/main/java/com/seank/kotlinflowplayground/di/ApplicationModule.kt
@@ -5,14 +5,14 @@ import android.content.Context
 import com.seank.kotlinflowplayground.data.CardsRepository
 import com.seank.kotlinflowplayground.data.CardsRepositoryImpl
 import com.seank.kotlinflowplayground.data.CardsService
-import com.seank.kotlinflowplayground.flow.DefaultDispatcherProvider
-import com.seank.kotlinflowplayground.flow.DispatcherProvider
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -35,8 +35,15 @@ class ApplicationModule(val application: Application) {
     @Provides
     @Singleton
     fun providesCardsService(moshi: Moshi) : CardsService {
+        val okHttpClient = OkHttpClient
+            .Builder()
+            .readTimeout(60L, TimeUnit.SECONDS)
+            .connectTimeout(60L, TimeUnit.SECONDS)
+            .build()
+
         return Retrofit.Builder()
             .baseUrl("https://api.magicthegathering.io")
+            .client(okHttpClient)
             .addConverterFactory(MoshiConverterFactory.create(moshi))
             .build().create(CardsService::class.java)
     }


### PR DESCRIPTION
Added OkHTTP dependency to set our own client on any Retrofit instances. Timeout increased to 60 seconds to account for slow API.